### PR TITLE
Configure Netlify deployments and fix SSL cert

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,9 @@
+[[redirects]]
+    from = "https://councilmatic.netlify.com/*"
+    to = "https://www.councilmatic.org/:splat"
+    status = 301
+
+[[redirects]]
+    from = "https://councilmatic.org/*"
+    to = "https://www.councilmatic.org/:splat"
+    status = 301


### PR DESCRIPTION
## Summary

Configure Netlify to deploy from the `deploy` branch and create a staging branch for `master`. In the process, confirm that the SSL certificate is properly provisioned.

Closes #9, closes #7.

## Notes

Turns out switching to Netlify did work. The SSL error must have been constrained to our server. Once this is in, I'll go ahead and clean out those old certs from the councilmatic staging server.

## Testing instructions

- Visit https://www.councilmatic.org and confirm that the SSL certificate is valid
- Visit the deploy preview and confirm that it looks good: https://deploy-preview-10--councilmatic.netlify.com/